### PR TITLE
feat(pipelines): add azure app authentication for pr website blob upload

### DIFF
--- a/.github/workflows/pr-website-deploy.yml
+++ b/.github/workflows/pr-website-deploy.yml
@@ -82,15 +82,23 @@ jobs:
           name: pr-website-artifacts
           path: ./pr-deploy-site/
 
+      - name: 'Login via Azure CLI'
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: Upload PR WebSite
         uses: azure/cli@v2
+        env:
+          AZCOPY_AUTO_LOGIN_TYPE: 'AZCLI'
         with:
           azcliversion: latest
           inlineScript: |
             az storage blob upload-batch \
               --destination '$web' \
               --source ./pr-deploy-site \
-              --subscription ${{ env.AZURE_SUBSCRIPTION }}
               --account-name ${{ env.AZURE_STORAGE }} \
               --destination-path ${{ env.DEPLOY_BASE_PATH }} \
               --auth-mode login \


### PR DESCRIPTION
## Previous Behavior

## New Behavior

Publishing assets to the Azure Storage Account container is now done through federated credentials.